### PR TITLE
Add JENKINS in RuleSet enum to support codenarc >= 3.5.0

### DIFF
--- a/codenarc-converter/src/main/java/org/sonar/plugins/groovy/codenarc/RuleSet.java
+++ b/codenarc-converter/src/main/java/org/sonar/plugins/groovy/codenarc/RuleSet.java
@@ -37,6 +37,7 @@ public enum RuleSet {
   GROOVYISM("groovyism"), // new in 0.16
   IMPORTS("imports"),
   JDBC("jdbc"), // new in 0.14
+  JENKINS("jenkins"),
   JUNIT("junit"),
   LOGGING("logging"),
   NAMING("naming"),


### PR DESCRIPTION
CodeNarc 3.5.0 adds 7 new rules that apply to *Jenkinsfile* (see [changelog](https://github.com/CodeNarc/CodeNarc/blob/master/CHANGELOG.md)).

To be able to build the plugin with this CodeNarc version or above, a new member should be added to the **RuleSet** enum.